### PR TITLE
Bug: Template::raw() throws type error when field value is null

### DIFF
--- a/src/formie/TrackedField.php
+++ b/src/formie/TrackedField.php
@@ -44,7 +44,7 @@ class TrackedField extends Hidden
 
     public function getEmailHtml(Submission $submission, Notification $notification, mixed $value, array $renderOptions = []): string|null|bool
     {
-        return Template::raw($value);
+        return Template::raw($value ?? '');
     }
 
     public static function displayName(): string


### PR DESCRIPTION
I’m encountering a type error when a tracked field value is `null`. Since the field can be saved as null, this currently causes a fatal error when rendering email HTML.

**Error Message:**
```
craft\helpers\Template::raw(): Argument #1 ($value) must be of type string, null given, 
called in /vendor/digitalpulsebe/craft-utm-tracker/src/formie/TrackedField.php on line 47
```

**Proposed solution**
Fallback to an empty string when the value is `null`
