### PR TITLE
Fix/utm storage initialization

### DIFF
--- a/src/UtmTracker.php
+++ b/src/UtmTracker.php
@@ -47,7 +47,7 @@ class UtmTracker extends Plugin
      */
     public static $plugin;
 
-    public ?StorageMethod $storage;
+    public ?StorageMethod $storage = null;
 
     // Public Properties
     // =========================================================================


### PR DESCRIPTION
**Error Message:**

```
NOTICE: PHP message: An Error occurred while handling another error:
Error: Typed property digitalpulsebe\utmtracker\UtmTracker::$storage must not be accessed before initialization in /var/task/vendor/digitalpulsebe/craft-utm-tracker/src/variables/UtmTrackerVariable.php:50
```

Bug with in newer versions of PHP (I can’t recall the specific version, but 8.2 or 8.3 or so).

**Proposed solution**
Initialise **$storage**  with **null**

`public ?StorageMethod $storage = null;`